### PR TITLE
Add database and server tools to skills

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -372,40 +372,24 @@
                             <div class="skill-header">
                                 <i class="fab fa-html5"></i>
                                 <span class="skill-name">HTML5</span>
-                                <span class="skill-percentage">95%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="95"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fab fa-css3-alt"></i>
                                 <span class="skill-name">CSS3</span>
-                                <span class="skill-percentage">90%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="90"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fab fa-js-square"></i>
                                 <span class="skill-name">JavaScript</span>
-                                <span class="skill-percentage">88%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="88"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fab fa-bootstrap"></i>
                                 <span class="skill-name">Bootstrap</span>
-                                <span class="skill-percentage">85%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="85"></div>
                             </div>
                         </div>
                     </div>
@@ -421,90 +405,54 @@
                             <div class="skill-header">
                                 <i class="fab fa-node-js"></i>
                                 <span class="skill-name">Node.js</span>
-                                <span class="skill-percentage">90%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="90"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-route"></i>
                                 <span class="skill-name">Express</span>
-                                <span class="skill-percentage">88%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="88"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fab fa-python"></i>
                                 <span class="skill-name">Python</span>
-                                <span class="skill-percentage">82%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="82"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fab fa-linux"></i>
                                 <span class="skill-name">Linux</span>
-                                <span class="skill-percentage">80%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="80"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-database"></i>
                                 <span class="skill-name">MySQL</span>
-                                <span class="skill-percentage">85%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="85"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-database"></i>
                                 <span class="skill-name">MariaDB</span>
-                                <span class="skill-percentage">80%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="80"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-terminal"></i>
                                 <span class="skill-name">PuTTY</span>
-                                <span class="skill-percentage">75%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="75"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-server"></i>
                                 <span class="skill-name">Server</span>
-                                <span class="skill-percentage">80%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="80"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-infinity"></i>
                                 <span class="skill-name">Forever</span>
-                                <span class="skill-percentage">70%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="70"></div>
                             </div>
                         </div>
                     </div>
@@ -520,60 +468,36 @@
                             <div class="skill-header">
                                 <i class="fas fa-users"></i>
                                 <span class="skill-name">Team Leadership</span>
-                                <span class="skill-percentage">92%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="92"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-robot"></i>
                                 <span class="skill-name">Gemini API</span>
-                                <span class="skill-percentage">75%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="75"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-microphone"></i>
                                 <span class="skill-name">ElevenLabs</span>
-                                <span class="skill-percentage">80%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="80"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-brain"></i>
                                 <span class="skill-name">AI/ML</span>
-                                <span class="skill-percentage">75%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="75"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-shopping-cart"></i>
                                 <span class="skill-name">MercadoLibre API</span>
-                                <span class="skill-percentage">90%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="90"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-cogs"></i>
                                 <span class="skill-name">Automatizaciones</span>
-                                <span class="skill-percentage">88%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="88"></div>
                             </div>
                         </div>
                     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -159,6 +159,26 @@
                                 <i class="fas fa-robot"></i>
                                 <span>Gemini API</span>
                             </div>
+                            <div class="tech-item">
+                                <i class="fas fa-database"></i>
+                                <span>MySQL</span>
+                            </div>
+                            <div class="tech-item">
+                                <i class="fas fa-database"></i>
+                                <span>MariaDB</span>
+                            </div>
+                            <div class="tech-item">
+                                <i class="fas fa-terminal"></i>
+                                <span>PuTTY</span>
+                            </div>
+                            <div class="tech-item">
+                                <i class="fas fa-server"></i>
+                                <span>Server</span>
+                            </div>
+                            <div class="tech-item">
+                                <i class="fas fa-infinity"></i>
+                                <span>Forever</span>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -435,6 +455,56 @@
                             </div>
                             <div class="skill-bar">
                                 <div class="skill-progress" data-width="80"></div>
+                            </div>
+                        </div>
+                        <div class="skill-item">
+                            <div class="skill-header">
+                                <i class="fas fa-database"></i>
+                                <span class="skill-name">MySQL</span>
+                                <span class="skill-percentage">85%</span>
+                            </div>
+                            <div class="skill-bar">
+                                <div class="skill-progress" data-width="85"></div>
+                            </div>
+                        </div>
+                        <div class="skill-item">
+                            <div class="skill-header">
+                                <i class="fas fa-database"></i>
+                                <span class="skill-name">MariaDB</span>
+                                <span class="skill-percentage">80%</span>
+                            </div>
+                            <div class="skill-bar">
+                                <div class="skill-progress" data-width="80"></div>
+                            </div>
+                        </div>
+                        <div class="skill-item">
+                            <div class="skill-header">
+                                <i class="fas fa-terminal"></i>
+                                <span class="skill-name">PuTTY</span>
+                                <span class="skill-percentage">75%</span>
+                            </div>
+                            <div class="skill-bar">
+                                <div class="skill-progress" data-width="75"></div>
+                            </div>
+                        </div>
+                        <div class="skill-item">
+                            <div class="skill-header">
+                                <i class="fas fa-server"></i>
+                                <span class="skill-name">Server</span>
+                                <span class="skill-percentage">80%</span>
+                            </div>
+                            <div class="skill-bar">
+                                <div class="skill-progress" data-width="80"></div>
+                            </div>
+                        </div>
+                        <div class="skill-item">
+                            <div class="skill-header">
+                                <i class="fas fa-infinity"></i>
+                                <span class="skill-name">Forever</span>
+                                <span class="skill-percentage">70%</span>
+                            </div>
+                            <div class="skill-bar">
+                                <div class="skill-progress" data-width="70"></div>
                             </div>
                         </div>
                     </div>

--- a/src/Public/index.html
+++ b/src/Public/index.html
@@ -372,40 +372,24 @@
                             <div class="skill-header">
                                 <i class="fab fa-html5"></i>
                                 <span class="skill-name">HTML5</span>
-                                <span class="skill-percentage">95%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="95"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fab fa-css3-alt"></i>
                                 <span class="skill-name">CSS3</span>
-                                <span class="skill-percentage">90%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="90"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fab fa-js-square"></i>
                                 <span class="skill-name">JavaScript</span>
-                                <span class="skill-percentage">88%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="88"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fab fa-bootstrap"></i>
                                 <span class="skill-name">Bootstrap</span>
-                                <span class="skill-percentage">85%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="85"></div>
                             </div>
                         </div>
                     </div>
@@ -421,90 +405,54 @@
                             <div class="skill-header">
                                 <i class="fab fa-node-js"></i>
                                 <span class="skill-name">Node.js</span>
-                                <span class="skill-percentage">90%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="90"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-route"></i>
                                 <span class="skill-name">Express</span>
-                                <span class="skill-percentage">88%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="88"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fab fa-python"></i>
                                 <span class="skill-name">Python</span>
-                                <span class="skill-percentage">82%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="82"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fab fa-linux"></i>
                                 <span class="skill-name">Linux</span>
-                                <span class="skill-percentage">80%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="80"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-database"></i>
                                 <span class="skill-name">MySQL</span>
-                                <span class="skill-percentage">85%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="85"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-database"></i>
                                 <span class="skill-name">MariaDB</span>
-                                <span class="skill-percentage">80%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="80"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-terminal"></i>
                                 <span class="skill-name">PuTTY</span>
-                                <span class="skill-percentage">75%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="75"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-server"></i>
                                 <span class="skill-name">Server</span>
-                                <span class="skill-percentage">80%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="80"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-infinity"></i>
                                 <span class="skill-name">Forever</span>
-                                <span class="skill-percentage">70%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="70"></div>
                             </div>
                         </div>
                     </div>
@@ -520,60 +468,36 @@
                             <div class="skill-header">
                                 <i class="fas fa-users"></i>
                                 <span class="skill-name">Team Leadership</span>
-                                <span class="skill-percentage">92%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="92"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-robot"></i>
                                 <span class="skill-name">Gemini API</span>
-                                <span class="skill-percentage">75%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="75"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-microphone"></i>
                                 <span class="skill-name">ElevenLabs</span>
-                                <span class="skill-percentage">80%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="80"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-brain"></i>
                                 <span class="skill-name">AI/ML</span>
-                                <span class="skill-percentage">75%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="75"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-shopping-cart"></i>
                                 <span class="skill-name">MercadoLibre API</span>
-                                <span class="skill-percentage">90%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="90"></div>
                             </div>
                         </div>
                         <div class="skill-item">
                             <div class="skill-header">
                                 <i class="fas fa-cogs"></i>
                                 <span class="skill-name">Automatizaciones</span>
-                                <span class="skill-percentage">88%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-width="88"></div>
                             </div>
                         </div>
                     </div>

--- a/src/Public/index.html
+++ b/src/Public/index.html
@@ -159,6 +159,26 @@
                                 <i class="fas fa-robot"></i>
                                 <span>Gemini API</span>
                             </div>
+                            <div class="tech-item">
+                                <i class="fas fa-database"></i>
+                                <span>MySQL</span>
+                            </div>
+                            <div class="tech-item">
+                                <i class="fas fa-database"></i>
+                                <span>MariaDB</span>
+                            </div>
+                            <div class="tech-item">
+                                <i class="fas fa-terminal"></i>
+                                <span>PuTTY</span>
+                            </div>
+                            <div class="tech-item">
+                                <i class="fas fa-server"></i>
+                                <span>Server</span>
+                            </div>
+                            <div class="tech-item">
+                                <i class="fas fa-infinity"></i>
+                                <span>Forever</span>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -435,6 +455,56 @@
                             </div>
                             <div class="skill-bar">
                                 <div class="skill-progress" data-width="80"></div>
+                            </div>
+                        </div>
+                        <div class="skill-item">
+                            <div class="skill-header">
+                                <i class="fas fa-database"></i>
+                                <span class="skill-name">MySQL</span>
+                                <span class="skill-percentage">85%</span>
+                            </div>
+                            <div class="skill-bar">
+                                <div class="skill-progress" data-width="85"></div>
+                            </div>
+                        </div>
+                        <div class="skill-item">
+                            <div class="skill-header">
+                                <i class="fas fa-database"></i>
+                                <span class="skill-name">MariaDB</span>
+                                <span class="skill-percentage">80%</span>
+                            </div>
+                            <div class="skill-bar">
+                                <div class="skill-progress" data-width="80"></div>
+                            </div>
+                        </div>
+                        <div class="skill-item">
+                            <div class="skill-header">
+                                <i class="fas fa-terminal"></i>
+                                <span class="skill-name">PuTTY</span>
+                                <span class="skill-percentage">75%</span>
+                            </div>
+                            <div class="skill-bar">
+                                <div class="skill-progress" data-width="75"></div>
+                            </div>
+                        </div>
+                        <div class="skill-item">
+                            <div class="skill-header">
+                                <i class="fas fa-server"></i>
+                                <span class="skill-name">Server</span>
+                                <span class="skill-percentage">80%</span>
+                            </div>
+                            <div class="skill-bar">
+                                <div class="skill-progress" data-width="80"></div>
+                            </div>
+                        </div>
+                        <div class="skill-item">
+                            <div class="skill-header">
+                                <i class="fas fa-infinity"></i>
+                                <span class="skill-name">Forever</span>
+                                <span class="skill-percentage">70%</span>
+                            </div>
+                            <div class="skill-bar">
+                                <div class="skill-progress" data-width="70"></div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- highlight MySQL, MariaDB, PuTTY, Server, and Forever in tech stack
- showcase these tools in backend skills with progress bars

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a01bf2b9288326884ed40987a9160d